### PR TITLE
Support touch events on desktop + Add GH demo page 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+Viewpager.js
+============
+Paging views like a boss. 
+
+## Examples
+
+- [Scroller](http://eyecatchup.github.io/viewpager.js/examples/scroller/index.html)
+- [Simple Slider](http://eyecatchup.github.io/viewpager.js/examples/simpleslider/index.html)
+- [Simple Vertical](http://eyecatchup.github.io/viewpager.js/examples/simplevertical/index.html)
+- [Simple Vertical (Prevent all native scroll)](http://eyecatchup.github.io/viewpager.js/examples/simplevertical_preventallnativescroll/index.html)
+- [Simple Vertical (Tipping Point)](http://eyecatchup.github.io/viewpager.js/examples/simplevertical_tipping_point/index.html)
+- [Spinner](http://eyecatchup.github.io/viewpager.js/examples/spinner/index.html)
+
+## Copyright / License
+
+(c) Anton Johansson <hello@antonj.se>, Fredrik Jonsson <hello@fredrikj.se>   
+License: MIT   
+ 

--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
     "slideshow"
   ],
   "license": "MIT",
-  "homepage": "viewpager.com",
+  "homepage": "http://github.com/antonj/viewpager.js",
   "private": true,
   "ignore": [
     "**/.*",

--- a/examples/fingerblast.js
+++ b/examples/fingerblast.js
@@ -1,0 +1,273 @@
+// FINGERBLAST.js
+// --------------
+// Adapted from phantom limb by Brian Cartensen
+
+/* jshint bitwise: false */
+/* global GLOBAL: true */
+
+(function () {
+
+  'use strict';
+
+  function FingerBlast(element) {
+    this.element = typeof element === 'string' ? document.querySelector(element) : element;
+
+    if (this.element) {
+      this.listen();
+    }
+  }
+
+  FingerBlast.prototype = {
+    x: NaN,
+    y: NaN,
+
+    startDistance: NaN,
+    startAngle:    NaN,
+
+    mouseIsDown: false,
+
+    listen: function () {
+      var activate = this.activate.bind(this);
+      var deactivate = this.deactivate.bind(this);
+
+      function contains (element, ancestor) {
+        var descendants;
+        var index;
+        var descendant;
+
+        if (!element) {
+          return;
+        }
+
+        if ('compareDocumentPosition' in ancestor) {
+          return !!(ancestor.compareDocumentPosition(element) & 16);
+        } else if ('contains' in ancestor) {
+          return ancestor !== element && ancestor.contains(element);
+        } else {
+          for ((descendants = ancestor.getElementsByTagName('*')), index = 0; (descendant = descendants[index++]);) {
+            if (descendant === element) {
+              return true;
+            }
+          }
+          return false;
+        }
+      }
+
+      this.element.addEventListener('mouseover', function (e) {
+        var target = e.relatedTarget;
+        if (target !== this && !contains(target, this)) {
+          activate();
+        }
+      });
+
+      this.element.addEventListener('mouseout', function (e) {
+        var target = e.relatedTarget;
+        if (target !== this && !contains(target, this)) {
+          deactivate(e);
+        }
+      });
+    },
+
+    activate: function () {
+      if (this.active) {
+        return;
+      }
+      this.element.addEventListener('mousedown', (this.touchStart = this.touchStart.bind(this)), true);
+      this.element.addEventListener('mousemove', (this.touchMove  = this.touchMove.bind(this)),  true);
+      this.element.addEventListener('mouseup',   (this.touchEnd   = this.touchEnd.bind(this)),   true);
+      this.element.addEventListener('click',     (this.click      = this.click.bind(this)),      true);
+      this.active = true;
+    },
+
+    deactivate: function (e) {
+      this.active = false;
+      if (this.mouseIsDown) {
+        this.touchEnd(e);
+      }
+      this.element.removeEventListener('mousedown', this.touchStart, true);
+      this.element.removeEventListener('mousemove', this.touchMove,  true);
+      this.element.removeEventListener('mouseup',   this.touchEnd,   true);
+      this.element.removeEventListener('click',     this.click,      true);
+    },
+
+    click: function (e) {
+      if (e.synthetic) {
+        return;
+      }
+      e.preventDefault();
+      e.stopPropagation();
+    },
+
+    touchStart: function (e) {
+      if (e.synthetic || /input|textarea/.test(e.target.tagName.toLowerCase())) {
+        return;
+      }
+
+      this.mouseIsDown = true;
+
+      e.preventDefault();
+      e.stopPropagation();
+
+      this.fireTouchEvents('touchstart', e);
+    },
+
+    touchMove: function (e) {
+      if (e.synthetic) {
+        return;
+      }
+
+      e.preventDefault();
+      e.stopPropagation();
+
+      this.move(e.clientX, e.clientY);
+
+      if (this.mouseIsDown) {
+        this.fireTouchEvents('touchmove', e);
+      }
+    },
+
+    touchEnd: function (e) {
+      if (e.synthetic) {
+        return;
+      }
+
+      this.mouseIsDown = false;
+
+      e.preventDefault();
+      e.stopPropagation();
+
+      this.fireTouchEvents('touchend', e);
+
+      if (!this.target) {
+        return;
+      }
+
+      // Mobile Safari moves all the mouse events to fire after the touchend event.
+      this.target.dispatchEvent(this.createMouseEvent('mouseover', e));
+      this.target.dispatchEvent(this.createMouseEvent('mousemove', e));
+      this.target.dispatchEvent(this.createMouseEvent('mousedown', e));
+    },
+
+    fireTouchEvents: function (eventName, originalEvent) {
+      var events   = [];
+      var gestures = [];
+
+      if (!this.target) {
+        return;
+      }
+
+      // Convert 'ontouch*' properties and attributes to listeners.
+      var onEventName = 'on' + eventName;
+
+      if (onEventName in this.target) {
+        console.warn('Converting `' + onEventName + '` property to event listener.', this.target);
+        this.target.addEventListener(eventName, this.target[onEventName], false);
+        delete this.target[onEventName];
+      }
+
+      if (this.target.hasAttribute(onEventName)) {
+        console.warn('Converting `' + onEventName + '` attribute to event listener.', this.target);
+        var handler = new GLOBAL.Function('event', this.target.getAttribute(onEventName));
+        this.target.addEventListener(eventName, handler, false);
+        this.target.removeAttribute(onEventName);
+      }
+
+      // Set up a new event with the coordinates of the finger.
+      var touch = this.createMouseEvent(eventName, originalEvent);
+
+      events.push(touch);
+
+      // Figure out scale and rotation.
+      if (events.length > 1) {
+        var x = events[0].pageX - events[1].pageX;
+        var y = events[0].pageY - events[1].pageY;
+
+        var distance = Math.sqrt(Math.pow(x, 2) + Math.pow(y, 2));
+        var angle = Math.atan2(x, y) * (180 / Math.PI);
+
+        var gestureName = 'gesturechange';
+
+        if (eventName === 'touchstart') {
+          gestureName = 'gesturestart';
+          this.startDistance = distance;
+          this.startAngle = angle;
+        }
+
+        if (eventName === 'touchend') {
+          gestureName = 'gestureend';
+        }
+
+        events.forEach(function (event) {
+          var gesture = this.createMouseEvent.call(event._finger, gestureName, event);
+          gestures.push(gesture);
+        }.bind(this));
+
+        events.concat(gestures).forEach(function (event) {
+          event.scale = distance / this.startDistance;
+          event.rotation = this.startAngle - angle;
+        });
+      }
+
+      // Loop through the events array and fill in each touch array.
+      events.forEach(function (touch) {
+        touch.touches = events.filter(function (e) {
+          return ~e.type.indexOf('touch') && e.type !== 'touchend';
+        });
+
+        touch.changedTouches = events.filter(function (e) {
+          return ~e.type.indexOf('touch') && e._finger.target === touch._finger.target;
+        });
+
+        touch.targetTouches = touch.changedTouches.filter(function (e) {
+          return ~e.type.indexOf('touch') && e.type !== 'touchend';
+        });
+      });
+
+      // Then fire the events.
+      events.concat(gestures).forEach(function (event, i) {
+        event.identifier = i;
+        event._finger.target.dispatchEvent(event);
+      });
+    },
+
+    createMouseEvent: function (eventName, originalEvent) {
+      var e = new MouseEvent(eventName, {
+        view       : window,
+        detail     : originalEvent.detail,
+        bubbles    : true,
+        cancelable : true,
+        target     : this.target || originalEvent.relatedTarget,
+        clientX    : this.x || originalEvent.clientX,
+        clientY    : this.y || originalEvent.clientY,
+        screenX    : this.x || originalEvent.screenX,
+        screenY    : this.y || originalEvent.screenY,
+        ctrlKey    : originalEvent.ctrlKey,
+        shiftKey   : originalEvent.shiftKey,
+        altKey     : originalEvent.altKey,
+        metaKey    : originalEvent.metaKey,
+        button     : originalEvent.button
+      });
+
+      e.synthetic = true;
+      e._finger   = this;
+
+      return e;
+    },
+
+    move: function (x, y) {
+      if (isNaN(x) || isNaN(y)) {
+        this.target = null;
+      } else {
+        this.x = x;
+        this.y = y;
+
+        if (!this.mouseIsDown) {
+          this.target = document.elementFromPoint(x, y);
+        }
+      }
+    }
+  };
+
+  window.FingerBlast = FingerBlast;
+
+}());

--- a/examples/scroller/index.html
+++ b/examples/scroller/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
-    <meta charset="UTF-8" /> 
+    <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0" />
     <link rel="stylesheet" href="style.css" type="text/css" media="screen" />
     <title></title>
@@ -14,6 +14,8 @@
     <script type="text/javascript" src="../../src/scroller.js"></script>
     <script type="text/javascript" src="../../dist/velocity_tracker.js"></script>
     <script type="text/javascript" src="../../dist//gesture_detector.js"></script>
+    <!-- Helper library to enable touch events on desktop. -->
+    <script type="text/javascript" src="../fingerblast.js"></script>
     <script type="text/javascript" src="main.js"></script>
   </body>
 </html>

--- a/examples/scroller/main.js
+++ b/examples/scroller/main.js
@@ -86,8 +86,8 @@ function update() {
 
                  cy + v.vy * 100);
   context.stroke();
-  
-  
+
+
   // if (animating) {
   requestAnimationFrame(update);
   // }
@@ -101,7 +101,7 @@ requestAnimationFrame(update);
 //   var m_dx = 0;
 //   var m_dy = 0;
 //   var m_dt = 0;
-  
+
 //   var events = {
 //     handleEvent : function (event) {
 //       switch (event.type) {
@@ -158,7 +158,7 @@ requestAnimationFrame(update);
 //                      v.vy * 1000); //velocityY
 //     }
 //   }
-  
+
 //   area.addEventListener('mousedown', events);
 //   area.addEventListener('mousemove', events);
 //   area.addEventListener('mouseup', events);
@@ -168,3 +168,21 @@ requestAnimationFrame(update);
 // }
 
 // mouseListener();
+
+// To enable touch events on desktop.
+// Note: Remove this when building Cordova/PhoneGap apps!
+var isMobileUA = function () {
+    return navigator.userAgent.match(/Android/i)
+      || navigator.userAgent.match(/webOS/i)
+      || navigator.userAgent.match(/iPhone/i)
+      || navigator.userAgent.match(/iPad/i)
+      || navigator.userAgent.match(/iPod/i)
+      || navigator.userAgent.match(/BlackBerry/i)
+      || navigator.userAgent.match(/Windows Phone/i)
+    ? true
+    : false;
+};
+if (!isMobileUA()) {
+    console.log('No mobile user agent detected; initiating Fingerblast.js.')
+    window.onload = new FingerBlast('body');
+}

--- a/examples/simpleslider/index.html
+++ b/examples/simpleslider/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
-    <meta charset="UTF-8" /> 
+    <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, user-scalable=yes, initial-scale=1.0" />
     <link rel="stylesheet" href="style.css" type="text/css" media="screen" />
     <title></title>
@@ -17,6 +17,8 @@
       </div>
     </div>
     <script type="text/javascript" src="../../dist/viewpager.js"></script>
+    <!-- Helper library to enable touch events on desktop. -->
+    <script type="text/javascript" src="../fingerblast.js"></script>
     <script type="text/javascript" src="main.js"></script>
   </body>
 </html>

--- a/examples/simpleslider/main.js
+++ b/examples/simpleslider/main.js
@@ -29,3 +29,21 @@ var vp = new ViewPager(view_pager_elem, {
 // document.getElementById('next').addEventListener('click', function () {
 //   vp.next();
 // });
+
+// To enable touch events on desktop.
+// Note: Remove this when building Cordova/PhoneGap apps!
+var isMobileUA = function () {
+    return navigator.userAgent.match(/Android/i)
+      || navigator.userAgent.match(/webOS/i)
+      || navigator.userAgent.match(/iPhone/i)
+      || navigator.userAgent.match(/iPad/i)
+      || navigator.userAgent.match(/iPod/i)
+      || navigator.userAgent.match(/BlackBerry/i)
+      || navigator.userAgent.match(/Windows Phone/i)
+    ? true
+    : false;
+};
+if (!isMobileUA()) {
+    console.log('No mobile user agent detected; initiating Fingerblast.js.')
+    window.onload = new FingerBlast(view_pager_elem);
+}

--- a/examples/simplevertical/index.html
+++ b/examples/simplevertical/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
-    <meta charset="UTF-8" /> 
+    <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, user-scalable=yes, initial-scale=1.0" />
     <link rel="stylesheet" href="style.css" type="text/css" media="screen" />
     <title></title>
@@ -17,6 +17,8 @@
       </div>
     </div>
     <script type="text/javascript" src="../../dist/viewpager.js"></script>
+    <!-- Helper library to enable touch events on desktop. -->
+    <script type="text/javascript" src="../fingerblast.js"></script>
     <script type="text/javascript" src="main.js"></script>
   </body>
 </html>

--- a/examples/simplevertical/main.js
+++ b/examples/simplevertical/main.js
@@ -29,3 +29,21 @@ var vp = new ViewPager(view_pager_elem, {
 // document.getElementById('next').addEventListener('click', function () {
 //   vp.next();
 // });
+
+// To enable touch events on desktop.
+// Note: Remove this when building Cordova/PhoneGap apps!
+var isMobileUA = function () {
+    return navigator.userAgent.match(/Android/i)
+      || navigator.userAgent.match(/webOS/i)
+      || navigator.userAgent.match(/iPhone/i)
+      || navigator.userAgent.match(/iPad/i)
+      || navigator.userAgent.match(/iPod/i)
+      || navigator.userAgent.match(/BlackBerry/i)
+      || navigator.userAgent.match(/Windows Phone/i)
+    ? true
+    : false;
+};
+if (!isMobileUA()) {
+    console.log('No mobile user agent detected; initiating Fingerblast.js.')
+    window.onload = new FingerBlast(view_pager_elem);
+}

--- a/examples/simplevertical_preventallnativescroll/index.html
+++ b/examples/simplevertical_preventallnativescroll/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
-    <meta charset="UTF-8" /> 
+    <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, user-scalable=yes, initial-scale=1.0" />
     <link rel="stylesheet" href="style.css" type="text/css" media="screen" />
     <title></title>
@@ -17,6 +17,8 @@
       </div>
     </div>
     <script type="text/javascript" src="../../dist/viewpager.js"></script>
+    <!-- Helper library to enable touch events on desktop. -->
+    <script type="text/javascript" src="../fingerblast.js"></script>
     <script type="text/javascript" src="main.js"></script>
   </body>
 </html>

--- a/examples/simplevertical_preventallnativescroll/main.js
+++ b/examples/simplevertical_preventallnativescroll/main.js
@@ -30,3 +30,21 @@ var vp = new ViewPager(view_pager_elem, {
 // document.getElementById('next').addEventListener('click', function () {
 //   vp.next();
 // });
+
+// To enable touch events on desktop.
+// Note: Remove this when building Cordova/PhoneGap apps!
+var isMobileUA = function () {
+    return navigator.userAgent.match(/Android/i)
+      || navigator.userAgent.match(/webOS/i)
+      || navigator.userAgent.match(/iPhone/i)
+      || navigator.userAgent.match(/iPad/i)
+      || navigator.userAgent.match(/iPod/i)
+      || navigator.userAgent.match(/BlackBerry/i)
+      || navigator.userAgent.match(/Windows Phone/i)
+    ? true
+    : false;
+};
+if (!isMobileUA()) {
+    console.log('No mobile user agent detected; initiating Fingerblast.js.')
+    window.onload = new FingerBlast(view_pager_elem);
+}

--- a/examples/simplevertical_tipping_point/index.html
+++ b/examples/simplevertical_tipping_point/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
-    <meta charset="UTF-8" /> 
+    <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, user-scalable=yes, initial-scale=1.0" />
     <link rel="stylesheet" href="style.css" type="text/css" media="screen" />
     <title></title>
@@ -17,6 +17,8 @@
       </div>
     </div>
     <script type="text/javascript" src="../../dist/viewpager.js"></script>
+    <!-- Helper library to enable touch events on desktop. -->
+    <script type="text/javascript" src="../fingerblast.js"></script>
     <script type="text/javascript" src="main.js"></script>
   </body>
 </html>

--- a/examples/simplevertical_tipping_point/main.js
+++ b/examples/simplevertical_tipping_point/main.js
@@ -30,3 +30,21 @@ var vp = new ViewPager(view_pager_elem, {
 // document.getElementById('next').addEventListener('click', function () {
 //   vp.next();
 // });
+
+// To enable touch events on desktop.
+// Note: Remove this when building Cordova/PhoneGap apps!
+var isMobileUA = function () {
+    return navigator.userAgent.match(/Android/i)
+      || navigator.userAgent.match(/webOS/i)
+      || navigator.userAgent.match(/iPhone/i)
+      || navigator.userAgent.match(/iPad/i)
+      || navigator.userAgent.match(/iPod/i)
+      || navigator.userAgent.match(/BlackBerry/i)
+      || navigator.userAgent.match(/Windows Phone/i)
+    ? true
+    : false;
+};
+if (!isMobileUA()) {
+    console.log('No mobile user agent detected; initiating Fingerblast.js.')
+    window.onload = new FingerBlast(view_pager_elem);
+}

--- a/examples/spinner/index.html
+++ b/examples/spinner/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
-    <meta charset="UTF-8" /> 
+    <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0" />
     <link rel="stylesheet" href="style.css" type="text/css" media="screen" />
     <title></title>
@@ -14,6 +14,8 @@
     <script type="text/javascript" src="../../src/scroller.js"></script>
     <script type="text/javascript" src="../../dist/velocity_tracker.js"></script>
     <script type="text/javascript" src="../../dist//gesture_detector.js"></script>
+    <!-- Helper library to enable touch events on desktop. -->
+    <script type="text/javascript" src="../fingerblast.js"></script>
     <script type="text/javascript" src="main.js"></script>
   </body>
 </html>

--- a/examples/spinner/main.js
+++ b/examples/spinner/main.js
@@ -44,7 +44,7 @@ var gd = new GestureDetector(area, {
       p.event.preventDefault();
     }
   },
-  
+
   onDrag : function (p) {
     if (!active) return;
     scroller.forceFinished(true);
@@ -85,7 +85,7 @@ function update() {
     if (scrollX === 0 || scrollX === w) {
       scroller.forceFinished(true);
     }
-  
+
     position.x = scrollX;
     console.log(position.x);
   }
@@ -98,7 +98,7 @@ function update() {
   var val = clamp(roundTo(position.x, STEPS) / (STEPS * 2), 0, 8);
 
   context.clearRect ( 0 , 0 , canvas.width, canvas.height );
-  
+
   context.fillStyle = 'black';
   context.fillText("" + val.toFixed(1), cx, cy + 10);
 
@@ -115,7 +115,7 @@ function update() {
     px += STEPS;
     big = !big;
   }
-  
+
 
   // Velo
   var v = vtracker.getVelocity();
@@ -206,3 +206,21 @@ requestAnimationFrame(update);
 // }
 
 // mouseListener();
+
+// To enable touch events on desktop.
+// Note: Remove this when building Cordova/PhoneGap apps!
+var isMobileUA = function () {
+    return navigator.userAgent.match(/Android/i)
+      || navigator.userAgent.match(/webOS/i)
+      || navigator.userAgent.match(/iPhone/i)
+      || navigator.userAgent.match(/iPad/i)
+      || navigator.userAgent.match(/iPod/i)
+      || navigator.userAgent.match(/BlackBerry/i)
+      || navigator.userAgent.match(/Windows Phone/i)
+    ? true
+    : false;
+};
+if (!isMobileUA()) {
+    console.log('No mobile user agent detected; initiating Fingerblast.js.')
+    window.onload = new FingerBlast('body');
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "viewpager.com",
+  "name": "viewpager.js",
   "version": "0.1.0",
   "repository" : {
       "type" : "git",


### PR DESCRIPTION
Hey there, this PR contains a few minor changes related to the examples. I wanted to have an online example and didn't found one. So, to create one, here're the changes I made on [my fork](https://github.com/eyecatchup/viewpager.js):
- Added [FingerBlast.js](https://github.com/stephanebachelier/fingerblast.js/blob/master/dist/fingerblast.js) to examples to support touch events on desktop.
- Created a gh-pages branch from master.
- Added a `README.md`, providing links to the examples (note: those links would need to be updated to fit **your** GitHub pages URL!).

Also, I removed references to the viewpager.com domain (since it seems to be no longer maintained). 

---

Just thought to share with you. If you like to, feel free to merge/adapt my changes. Otherwise just close this PR. :)

Cheers
.
